### PR TITLE
Add Japanese documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# libzkp
+
+Rustで実装された簡易ゼロ知識証明ライブラリです。範囲証明や等価性証明、
+閾値証明など複数のスキームを提供し、PyO3経由でPythonから利用できます。
+
+## 特徴
+- Rustによる高速かつ安全な実装
+- Pythonバインディングを標準搭載
+- Bulletproofs/SNARK/STARK など複数バックエンドの切り替えに対応
+
+## 使い方
+### Rust
+```bash
+cargo test
+```
+
+### Python
+maturin でビルドした wheel をインストールします。
+```bash
+maturin build -r -F pyo3/extension-module
+pip install target/wheels/libzkp-*.whl
+```
+Python からは以下のように利用できます。
+```python
+import libzkp
+proof, comm = libzkp.prove_range(10, 0, 20)
+assert libzkp.verify_range(proof, comm, 0, 20)
+```
+
+詳細なアーキテクチャやAPIの設計方針については `doc/` 以下を参照してください。

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,0 +1,30 @@
+# 概要
+
+本ライブラリはゼロ知識証明(ZKP)を学習・検証するためのサンプル実装です。
+`sekkei.md` に記載された設計方針に沿い、以下のモジュールを提供します。
+
+- `range_proof` 範囲証明
+- `equality_proof` 等価性証明
+- `threshold_proof` 閾値証明
+- `set_membership` 集合メンバーシップ証明
+- `improvement_proof` 改善証明
+- `consistency_proof` 一貫性証明
+
+Rust側ではそれぞれ `prove_*` と `verify_*` 関数を実装し、
+Python から呼び出せるよう PyO3 で公開しています。
+
+## ディレクトリ構成
+`sekkei.md` では以下のような構成例を示しています。
+```text
+libzkp/
+  src/
+    lib.rs                 # ルートモジュール（PyO3バインディング含む）
+    range_proof.rs         # 範囲証明
+    equality_proof.rs      # 等価性証明
+    threshold_proof.rs     # 閾値証明
+    set_membership.rs      # 集合メンバーシップ証明
+    improvement_proof.rs   # 改善証明
+    consistency_proof.rs   # 一貫性証明
+    backend/               # ZKPバックエンド抽象化
+  tests/                   # Rustのテスト
+```

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -1,0 +1,20 @@
+# 利用方法
+
+## Rust から利用する場合
+Cargo でビルドおよびテストを実行できます。
+```bash
+cargo test
+```
+
+## Python から利用する場合
+maturin を用いて wheel を作成し、`pip install` します。
+```bash
+maturin build -r -F pyo3/extension-module
+pip install target/wheels/libzkp-*.whl
+```
+インストール後は以下のように呼び出せます。
+```python
+import libzkp
+proof, comm = libzkp.prove_equality(5, 5)
+assert libzkp.verify_equality(proof, comm, 5, 5)
+```


### PR DESCRIPTION
## Summary
- add project README in Japanese
- document overview and usage under `doc/`

## Testing
- `cargo test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a23e9a3c8832686f6806d024aa331