### PR TITLE
Add Japanese README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
+# libzkp
 
+libzkp は、Python から利用可能なゼロ知識証明 (ZKP) ライブラリです。Rust で実装されており、`maturin` を用いて Python モジュールとしてビルドできます。
+
+このライブラリでは以下の証明を提供します：
+
+- 範囲証明 (range proof)
+- 値の等価性証明 (equality proof)
+- しきい値達成証明 (threshold proof)
+- 集合所属証明 (set membership proof)
+- 向上証明 (improvement proof)
+- 整合性証明 (consistency proof)
+
+各証明は Rust 側で実装された複数のバックエンドを利用しており、Bulletproofs、SNARK、STARK を簡易的に扱えるようになっています。
+
+## インストール
+
+ビルドには [maturin](https://github.com/PyO3/maturin) が必要です。
+
+```bash
+# Python モジュールとしてビルド
+maturin develop
+```
+
+## 使い方
+
+Python から呼び出す例：
+
+```python
+import libzkp
+
+proof = libzkp.prove_range(10, 0, 20)
+assert libzkp.verify_range(proof, 0, 20)
+```
+
+詳細な API については `docs/` 配下のドキュメントを参照してください。

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,38 @@
+# ドキュメント
+
+ここでは `libzkp` の各 API について簡単に説明します。
+
+## Python API
+
+| 関数名 | 説明 |
+| --- | --- |
+| `prove_range(value, min, max)` | `min` 以上 `max` 以下に値が存在することを示す範囲証明を生成します。 |
+| `verify_range(proof, min, max)` | 範囲証明を検証します。 |
+| `prove_equality(val1, val2)` | 2 つの値が等しいことを示す証明を生成します。 |
+| `verify_equality(proof, val1, val2)` | 等価性証明を検証します。 |
+| `prove_threshold(values, threshold)` | `values` の総和が `threshold` 以上であることを示す証明を生成します。 |
+| `verify_threshold(proof, threshold)` | しきい値証明を検証します。 |
+| `prove_membership(value, set)` | 値が集合 `set` に含まれることを示す証明を生成します。 |
+| `verify_membership(proof, set)` | 集合所属証明を検証します。 |
+| `prove_improvement(old, new)` | `old` から `new` へ値が増加したことを示す証明を生成します。 |
+| `verify_improvement(proof, old)` | 向上証明を検証します。 |
+| `prove_consistency(data)` | 昇順に並んだデータ列であることを示す整合性証明を生成します。 |
+| `verify_consistency(proof)` | 整合性証明を検証します。 |
+
+## ビルド方法
+
+```
+maturin develop
+```
+
+Rust のテストは以下で実行できます。
+
+```
+cargo test
+```
+
+Python 側のテストは次のように実行します。
+
+```
+pytest
+```


### PR DESCRIPTION
## Summary
- add a Japanese README
- create `docs/overview.md` in Japanese

## Testing
- `cargo test` *(fails: undefined references to python symbols)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'libzkp')*

------
https://chatgpt.com/codex/tasks/task_e_687a42078d48832689c466022affbb38