### PR TITLE
Improve SNARK and STARK implementations

### DIFF
--- a/src/backend/snark.rs
+++ b/src/backend/snark.rs
@@ -6,6 +6,7 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_snark::SNARK;
 use ark_std::rand::rngs::OsRng;
 use ark_std::UniformRand;
+use std::sync::OnceLock;
 
 #[derive(Clone)]
 struct EqualityCircuit {
@@ -20,61 +21,73 @@ struct EqualityCircuit {
 impl ConstraintSynthesizer<Fr> for EqualityCircuit {
     fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
         use ark_relations::r1cs::{LinearCombination, Variable};
-        
+
         let a_var = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
         let b_var = cs.new_witness_variable(|| self.b.ok_or(SynthesisError::AssignmentMissing))?;
-        let blinding_a_var = cs.new_witness_variable(|| self.blinding_a.ok_or(SynthesisError::AssignmentMissing))?;
-        let blinding_b_var = cs.new_witness_variable(|| self.blinding_b.ok_or(SynthesisError::AssignmentMissing))?;
-        
+        let blinding_a_var =
+            cs.new_witness_variable(|| self.blinding_a.ok_or(SynthesisError::AssignmentMissing))?;
+        let blinding_b_var =
+            cs.new_witness_variable(|| self.blinding_b.ok_or(SynthesisError::AssignmentMissing))?;
+
         let commit_a_var = cs.new_input_variable(|| Ok(self.commit_a))?;
         let commit_b_var = cs.new_input_variable(|| Ok(self.commit_b))?;
-        
+
         cs.enforce_constraint(
             LinearCombination::from(a_var),
             LinearCombination::from(Variable::One),
             LinearCombination::from(b_var),
         )?;
-        
+
         cs.enforce_constraint(
             LinearCombination::from(a_var) + LinearCombination::from(blinding_a_var),
             LinearCombination::from(Variable::One),
             LinearCombination::from(commit_a_var),
         )?;
-        
+
         cs.enforce_constraint(
             LinearCombination::from(b_var) + LinearCombination::from(blinding_b_var),
             LinearCombination::from(Variable::One),
             LinearCombination::from(commit_b_var),
         )?;
-        
+
         Ok(())
     }
 }
 
 pub struct SnarkBackend;
 
+static UNIVERSAL_SETUP: OnceLock<(
+    ark_groth16::ProvingKey<Bn254>,
+    ark_groth16::VerifyingKey<Bn254>,
+)> = OnceLock::new();
+
 impl SnarkBackend {
-    fn generate_universal_setup() -> (ark_groth16::ProvingKey<Bn254>, ark_groth16::VerifyingKey<Bn254>) {
-        let rng = &mut OsRng;
-        let dummy_circuit = EqualityCircuit {
-            a: Some(Fr::from(0u64)),
-            b: Some(Fr::from(0u64)),
-            commit_a: Fr::from(0u64),
-            commit_b: Fr::from(0u64),
-            blinding_a: Some(Fr::from(0u64)),
-            blinding_b: Some(Fr::from(0u64)),
-        };
-        Groth16::<Bn254>::circuit_specific_setup(dummy_circuit, rng).expect("setup failed")
+    fn get_universal_setup() -> &'static (
+        ark_groth16::ProvingKey<Bn254>,
+        ark_groth16::VerifyingKey<Bn254>,
+    ) {
+        UNIVERSAL_SETUP.get_or_init(|| {
+            let rng = &mut OsRng;
+            let dummy_circuit = EqualityCircuit {
+                a: Some(Fr::from(0u64)),
+                b: Some(Fr::from(0u64)),
+                commit_a: Fr::from(0u64),
+                commit_b: Fr::from(0u64),
+                blinding_a: Some(Fr::from(0u64)),
+                blinding_b: Some(Fr::from(0u64)),
+            };
+            Groth16::<Bn254>::circuit_specific_setup(dummy_circuit, rng).expect("setup failed")
+        })
     }
-    
+
     pub fn prove_equality_zk(a: u64, b: u64, blinding_a: Fr, blinding_b: Fr) -> Vec<u8> {
         if a != b {
             return vec![];
         }
-        
+
         let commit_a = Fr::from(a) + blinding_a;
         let commit_b = Fr::from(b) + blinding_b;
-        
+
         let circuit = EqualityCircuit {
             a: Some(Fr::from(a)),
             b: Some(Fr::from(b)),
@@ -83,42 +96,52 @@ impl SnarkBackend {
             blinding_a: Some(blinding_a),
             blinding_b: Some(blinding_b),
         };
-        
-        let (pk, vk) = Self::generate_universal_setup();
+
+        let setup = Self::get_universal_setup();
         let rng = &mut OsRng;
-        let proof = Groth16::<Bn254>::prove(&pk, circuit, rng).expect("proof generation failed");
-        
+        let proof =
+            Groth16::<Bn254>::prove(&setup.0, circuit, rng).expect("proof generation failed");
+
         let mut bytes = Vec::new();
-        vk.serialize_uncompressed(&mut bytes).expect("serialize vk");
-        proof.serialize_uncompressed(&mut bytes).expect("serialize proof");
-        commit_a.serialize_uncompressed(&mut bytes).expect("serialize commit_a");
-        commit_b.serialize_uncompressed(&mut bytes).expect("serialize commit_b");
+        setup
+            .1
+            .serialize_uncompressed(&mut bytes)
+            .expect("serialize vk");
+        proof
+            .serialize_uncompressed(&mut bytes)
+            .expect("serialize proof");
+        commit_a
+            .serialize_uncompressed(&mut bytes)
+            .expect("serialize commit_a");
+        commit_b
+            .serialize_uncompressed(&mut bytes)
+            .expect("serialize commit_b");
         bytes
     }
-    
+
     pub fn verify_equality_zk(proof_data: &[u8]) -> bool {
         let mut reader = proof_data;
-        
+
         let vk = match VerifyingKey::<Bn254>::deserialize_uncompressed(&mut reader) {
             Ok(vk) => vk,
             Err(_) => return false,
         };
-        
+
         let proof = match ark_groth16::Proof::<Bn254>::deserialize_uncompressed(&mut reader) {
             Ok(p) => p,
             Err(_) => return false,
         };
-        
+
         let commit_a = match Fr::deserialize_uncompressed(&mut reader) {
             Ok(c) => c,
             Err(_) => return false,
         };
-        
+
         let commit_b = match Fr::deserialize_uncompressed(&mut reader) {
             Ok(c) => c,
             Err(_) => return false,
         };
-        
+
         let pvk = Groth16::<Bn254>::process_vk(&vk).expect("process vk failed");
         Groth16::<Bn254>::verify_with_processed_vk(&pvk, &[commit_a, commit_b], &proof)
             .unwrap_or(false)
@@ -132,11 +155,11 @@ impl ZkpBackend for SnarkBackend {
         }
         let a = u64::from_le_bytes(data[0..8].try_into().unwrap());
         let b = u64::from_le_bytes(data[8..16].try_into().unwrap());
-        
+
         let rng = &mut OsRng;
         let blinding_a = Fr::rand(rng);
         let blinding_b = Fr::rand(rng);
-        
+
         Self::prove_equality_zk(a, b, blinding_a, blinding_b)
     }
 

--- a/src/equality_proof.rs
+++ b/src/equality_proof.rs
@@ -1,6 +1,7 @@
 use crate::backend::{snark::SnarkBackend, ZkpBackend};
 use crate::proof::{Proof, PROOF_VERSION};
 use pyo3::prelude::*;
+use sha2::{Digest, Sha256};
 
 const SCHEME_ID: u8 = 2;
 
@@ -11,19 +12,21 @@ pub fn prove_equality(val1: u64, val2: u64) -> PyResult<Vec<u8>> {
             "values are not equal",
         ));
     }
-    
+
     let mut data = Vec::new();
     data.extend_from_slice(&val1.to_le_bytes());
     data.extend_from_slice(&val2.to_le_bytes());
     let snark_proof = SnarkBackend::prove(&data);
-    
+
     if snark_proof.is_empty() {
         return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-            "SNARK proof generation failed"
+            "SNARK proof generation failed",
         ));
     }
-    
-    let commitment = vec![0u8; 32]; 
+
+    let mut hasher = Sha256::new();
+    hasher.update(&val1.to_le_bytes());
+    let commitment = hasher.finalize().to_vec();
     let proof = Proof::new(SCHEME_ID, snark_proof, commitment);
     Ok(proof.to_bytes())
 }
@@ -34,18 +37,18 @@ pub fn verify_equality(proof: Vec<u8>, val1: u64, val2: u64) -> PyResult<bool> {
         Some(p) => p,
         None => return Ok(false),
     };
-    
+
     if proof.version != PROOF_VERSION || proof.scheme != SCHEME_ID {
         return Ok(false);
     }
-    
+
     if val1 != val2 {
         return Ok(false);
     }
-    
+
     let mut data = Vec::new();
     data.extend_from_slice(&val1.to_le_bytes());
     data.extend_from_slice(&val2.to_le_bytes());
-    
+
     Ok(SnarkBackend::verify(&proof.proof, &data))
 }

--- a/src/improvement_proof.rs
+++ b/src/improvement_proof.rs
@@ -1,4 +1,3 @@
-
 use crate::backend::{stark::StarkBackend, ZkpBackend};
 use crate::proof::{Proof, PROOF_VERSION};
 use pyo3::prelude::*;
@@ -12,31 +11,25 @@ pub fn prove_improvement(old: u64, new: u64) -> PyResult<Vec<u8>> {
             "no improvement",
         ));
     }
-    
+
     let diff = new - old;
-    
-    let steps = if diff < 8 {
-        8 
-    } else {
-        diff.next_power_of_two().max(8)
-    };
-    
+
     let mut data = Vec::new();
     data.extend_from_slice(&old.to_le_bytes());
-    data.extend_from_slice(&steps.to_le_bytes());
-    
+    data.extend_from_slice(&new.to_le_bytes());
+
     let stark_proof = StarkBackend::prove(&data);
-    
+
     if stark_proof.is_empty() {
         return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-            "STARK proof generation failed"
+            "STARK proof generation failed",
         ));
     }
-    
+
     let mut commitment = Vec::new();
-    commitment.extend_from_slice(&diff.to_le_bytes()); 
-    commitment.extend_from_slice(&steps.to_le_bytes());
-    
+    commitment.extend_from_slice(&diff.to_le_bytes());
+    commitment.extend_from_slice(&new.to_le_bytes());
+
     let proof = Proof::new(SCHEME_ID, stark_proof, commitment);
     Ok(proof.to_bytes())
 }
@@ -47,37 +40,29 @@ pub fn verify_improvement(proof: Vec<u8>, old: u64) -> PyResult<bool> {
         Some(p) => p,
         None => return Ok(false),
     };
-    
+
     if proof.version != PROOF_VERSION || proof.scheme != SCHEME_ID {
         return Ok(false);
     }
-    
+
     if proof.commitment.len() != 16 {
         return Ok(false);
     }
-    
+
     let diff = u64::from_le_bytes(proof.commitment[0..8].try_into().unwrap());
-    let steps = u64::from_le_bytes(proof.commitment[8..16].try_into().unwrap());
-    
+    let new = u64::from_le_bytes(proof.commitment[8..16].try_into().unwrap());
+
     if diff == 0 {
         return Ok(false);
     }
-    
-    let _new = old + diff;
-    
-    let expected_steps = if diff < 8 {
-        8
-    } else {
-        diff.next_power_of_two().max(8)
-    };
-    
-    if steps != expected_steps {
+
+    if new != old + diff {
         return Ok(false);
     }
-    
+
     let mut data = Vec::new();
     data.extend_from_slice(&old.to_le_bytes());
-    data.extend_from_slice(&steps.to_le_bytes());
-    
+    data.extend_from_slice(&new.to_le_bytes());
+
     Ok(StarkBackend::verify(&proof.proof, &data))
 }


### PR DESCRIPTION
## Summary
- reuse Groth16 setup with a global `OnceLock`
- create a simple SHA-256 commitment in equality proofs
- update STARK backend to prove reaching an explicit final value
- adjust improvement proof to store the new value and use the updated STARK backend

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687f24c38c7c8326a528288bfb57a9e6