### PR TITLE
Improve equality proof verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ maturin develop
 
 ```python
 import libzkp
+import hashlib
 
 # 範囲証明: 値10が0以上20以下の範囲にあることを証明
 proof = libzkp.prove_range(10, 0, 20)
@@ -68,7 +69,8 @@ assert libzkp.verify_range(proof, 0, 20)
 
 # 等価性証明: 2つの値が等しいことを証明
 proof = libzkp.prove_equality(5, 5)
-assert libzkp.verify_equality(proof, 5, 5)
+commit = hashlib.sha256((5).to_bytes(8, 'little')).digest()
+assert libzkp.verify_equality(proof, commit)
 
 # しきい値証明: 値の合計が閾値以上であることを証明
 proof = libzkp.prove_threshold([1, 2, 3], 5)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,7 +9,7 @@
 | `prove_range(value, min, max)` | `min` 以上 `max` 以下に値が存在することを示す範囲証明を生成します。 |
 | `verify_range(proof, min, max)` | 範囲証明を検証します。 |
 | `prove_equality(val1, val2)` | 2 つの値が等しいことを示す証明を生成します。 |
-| `verify_equality(proof, val1, val2)` | 等価性証明を検証します。 |
+| `verify_equality(proof, commitment)` | 等価性証明を検証します。 |
 | `prove_threshold(values, threshold)` | `values` の総和が `threshold` 以上であることを示す証明を生成します。 |
 | `verify_threshold(proof, threshold)` | しきい値証明を検証します。 |
 | `prove_membership(value, set)` | 値が集合 `set` に含まれることを示す証明を生成します。 |

--- a/src/equality_proof.rs
+++ b/src/equality_proof.rs
@@ -32,7 +32,7 @@ pub fn prove_equality(val1: u64, val2: u64) -> PyResult<Vec<u8>> {
 }
 
 #[pyfunction]
-pub fn verify_equality(proof: Vec<u8>, val1: u64, val2: u64) -> PyResult<bool> {
+pub fn verify_equality(proof: Vec<u8>, expected_commitment: Vec<u8>) -> PyResult<bool> {
     let proof = match Proof::from_bytes(&proof) {
         Some(p) => p,
         None => return Ok(false),
@@ -42,13 +42,13 @@ pub fn verify_equality(proof: Vec<u8>, val1: u64, val2: u64) -> PyResult<bool> {
         return Ok(false);
     }
 
-    if val1 != val2 {
+    if expected_commitment.len() != 32 {
         return Ok(false);
     }
 
-    let mut data = Vec::new();
-    data.extend_from_slice(&val1.to_le_bytes());
-    data.extend_from_slice(&val2.to_le_bytes());
+    if proof.commitment != expected_commitment {
+        return Ok(false);
+    }
 
-    Ok(SnarkBackend::verify(&proof.proof, &data))
+    Ok(SnarkBackend::verify(&proof.proof, &[]))
 }


### PR DESCRIPTION
## Summary
- refine equality proof verification API to use a commitment instead of plain values
- document the new usage in README and overview docs

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68836d8241c0832687ea56d58a75675e